### PR TITLE
Ds/multihop feedback chan frozen proof gen

### DIFF
--- a/spec/core/ics-003-connection-semantics/README.md
+++ b/spec/core/ics-003-connection-semantics/README.md
@@ -242,7 +242,7 @@ function verifyMultihopMembership(
   connection: ConnectionEnd, // the connection end corresponding to the N-1'th chain in the channel path.
   height: Height,
   proof: MultihopProof,
-  connectionHops: String[],
+  connectionHops: Identifier[],
   key: CommitmentPath,
   value: bytes) {
 
@@ -266,7 +266,7 @@ function verifyMultihopNonMembership(
   connection: ConnectionEnd,
   height: Height,
   proof: MultihopProof,
-  connectionHops: String[],
+  connectionHops: Identifier[],
   key: CommitmentPath) {
     multihopConnectionEnd = abortTransactionUnless(getMultihopConnectionEnd(proof))
     prefix = multihopConnectionEnd.GetCounterparty().GetPrefix()


### PR DESCRIPTION
Incorporate latest PR feedback:
- show frozen client proof generation
- refactor getMaximumDelayPeriod to return timeDelay and blockDelay
- use standard types for keys, values, connectionHops
- add clarifying comments and fix some bugs in pseudo code